### PR TITLE
data.load_data(): Change label_col to be optional and add class_weights

### DIFF
--- a/multimodal_transformers/data/load_data.py
+++ b/multimodal_transformers/data/load_data.py
@@ -436,6 +436,8 @@ def load_data(
     logger.debug(f"Tokenized text example: {tokenized_text_ex}")
     if label_col:
         labels = data_df[label_col].values
+    else:
+        labels = None
 
     return TorchTabularTextDataset(
         hf_model_text_input,

--- a/multimodal_transformers/data/load_data.py
+++ b/multimodal_transformers/data/load_data.py
@@ -364,6 +364,7 @@ def load_data(
     max_token_length=None,
     debug=False,
     debug_dataset_size=100,
+    class_weights=None
 ):
     """Function to load a single dataset given a pandas DataFrame
 
@@ -403,6 +404,7 @@ def load_data(
         max_token_length (int, optional): The token length to pad or truncate to on the
             input text
         debug (bool, optional): Whether or not to load a smaller debug version of the dataset
+        class_weights (:obj:`list` of :obj:`float`, optional): The weights to assign to each class
 
     Returns:
         :obj:`tabular_torch_dataset.TorchTextDataset`: The converted dataset
@@ -446,4 +448,5 @@ def load_data(
         labels,
         data_df,
         label_list,
+        class_weights
     )

--- a/multimodal_transformers/data/load_data.py
+++ b/multimodal_transformers/data/load_data.py
@@ -352,7 +352,7 @@ def load_data(
     data_df,
     text_cols,
     tokenizer,
-    label_col,
+    label_col=None,
     label_list=None,
     categorical_cols=None,
     numerical_cols=None,
@@ -434,7 +434,8 @@ def load_data(
         tokenizer.convert_ids_to_tokens(hf_model_text_input["input_ids"][0])
     )
     logger.debug(f"Tokenized text example: {tokenized_text_ex}")
-    labels = data_df[label_col].values
+    if label_col:
+        labels = data_df[label_col].values
 
     return TorchTabularTextDataset(
         hf_model_text_input,


### PR DESCRIPTION
In this PR, we are moving the `label_col` argument in the `load_data()` function to be optional, it allows the usage of this function in training and inference use cases. The `TorchTabularTextDataset()` accepts the `labels` as None.

We are also adding the `class_weights` argument, which is accepted in the `TorchTabularTextDataset()`.