### PR TITLE
Fix TorchTabularTextDataset.__len__ method

### DIFF
--- a/multimodal_transformers/data/tabular_torch_dataset.py
+++ b/multimodal_transformers/data/tabular_torch_dataset.py
@@ -67,7 +67,7 @@ class TorchTabularTextDataset(TorchDataset):
         return item
 
     def __len__(self):
-        return len(self.encodings["input_ids"])
+        return len(self.encodings)
 
     def get_labels(self):
         """returns the label names for classification"""

--- a/multimodal_transformers/data/tabular_torch_dataset.py
+++ b/multimodal_transformers/data/tabular_torch_dataset.py
@@ -67,7 +67,7 @@ class TorchTabularTextDataset(TorchDataset):
         return item
 
     def __len__(self):
-        return len(self.encodings)
+        return len(self.encodings["input_ids"])
 
     def get_labels(self):
         """returns the label names for classification"""

--- a/multimodal_transformers/data/tabular_torch_dataset.py
+++ b/multimodal_transformers/data/tabular_torch_dataset.py
@@ -67,7 +67,7 @@ class TorchTabularTextDataset(TorchDataset):
         return item
 
     def __len__(self):
-        return len(self.labels)
+        return len(self.encodings["input_ids"])
 
     def get_labels(self):
         """returns the label names for classification"""


### PR DESCRIPTION
Since the TorchTabularTextDataset accepts the labels as None, we have an issue in the `__len__()` method that uses the `self.labels` to return the len.

In this PR, we suggest replacing it with the length of `self.encodings`. 