### PR TITLE
Fix(.):  Bugfixes

### DIFF
--- a/multimodal_transformers/data/load_data.py
+++ b/multimodal_transformers/data/load_data.py
@@ -363,8 +363,7 @@ def load_data(
     replace_empty_text=None,
     max_token_length=None,
     debug=False,
-    debug_dataset_size=100,
-    class_weights=None
+    debug_dataset_size=100
 ):
     """Function to load a single dataset given a pandas DataFrame
 
@@ -404,7 +403,6 @@ def load_data(
         max_token_length (int, optional): The token length to pad or truncate to on the
             input text
         debug (bool, optional): Whether or not to load a smaller debug version of the dataset
-        class_weights (:obj:`list` of :obj:`float`, optional): The weights to assign to each class
 
     Returns:
         :obj:`tabular_torch_dataset.TorchTextDataset`: The converted dataset
@@ -447,6 +445,5 @@ def load_data(
         numerical_feats,
         labels,
         data_df,
-        label_list,
-        class_weights
+        label_list
     )

--- a/multimodal_transformers/data/load_data.py
+++ b/multimodal_transformers/data/load_data.py
@@ -252,7 +252,7 @@ def load_train_val_test_helper(
 ):
     if categorical_encode_type == "ohe" or categorical_encode_type == "binary":
         dfs = [df for df in [train_df, val_df, test_df] if df is not None]
-        data_df = pd.concat(dfs, axis=0)
+        data_df = pd.concat(dfs, axis=0).reset_index(drop=False)
         cat_feat_processor = CategoricalFeatures(
             data_df, categorical_cols, categorical_encode_type
         )

--- a/multimodal_transformers/data/load_data.py
+++ b/multimodal_transformers/data/load_data.py
@@ -363,7 +363,7 @@ def load_data(
     replace_empty_text=None,
     max_token_length=None,
     debug=False,
-    debug_dataset_size=100
+    debug_dataset_size=100,
 ):
     """Function to load a single dataset given a pandas DataFrame
 
@@ -445,5 +445,5 @@ def load_data(
         numerical_feats,
         labels,
         data_df,
-        label_list
+        label_list,
     )

--- a/multimodal_transformers/data/tabular_torch_dataset.py
+++ b/multimodal_transformers/data/tabular_torch_dataset.py
@@ -18,8 +18,6 @@ class TorchTabularTextDataset(TorchDataset):
             An array containing the preprocessed numerical features
         labels (:class: list` or `numpy.ndarray`, `optional`, defaults to :obj:`None`):
             The labels of the training examples
-        class_weights (:class:`numpy.ndarray`, of shape (n_classes),  `optional`, defaults to :obj:`None`):
-            Class weights used for cross entropy loss for classification
         df (:class:`pandas.DataFrame`, `optional`, defaults to :obj:`None`):
             Model configuration class with all the parameters of the model.
             This object must also have a tabular_config member variable that is a
@@ -35,14 +33,12 @@ class TorchTabularTextDataset(TorchDataset):
         labels=None,
         df=None,
         label_list=None,
-        class_weights=None,
     ):
         self.df = df
         self.encodings = encodings
         self.cat_feats = categorical_feats
         self.numerical_feats = numerical_feats
         self.labels = labels
-        self.class_weights = class_weights
         self.label_list = (
             label_list
             if label_list is not None

--- a/multimodal_transformers/model/tabular_combiner.py
+++ b/multimodal_transformers/model/tabular_combiner.py
@@ -448,7 +448,7 @@ class TabularFeatCombiner(nn.Module):
             if cat_feats.shape[1] != 0:
                 if self.cat_feat_dim > self.text_out_dim:
                     cat_feats = self.cat_mlp(cat_feats)
-                w_cat = torch.mm(cat_feats, self.weight_cat) 
+                w_cat = torch.mm(cat_feats, self.weight_cat)
                 g_cat = (
                     (torch.cat([w_text, w_cat], dim=-1) * self.weight_a)
                     .sum(dim=1)

--- a/multimodal_transformers/model/tabular_config.py
+++ b/multimodal_transformers/model/tabular_config.py
@@ -32,6 +32,7 @@ class TabularConfig:
         gating_beta=0.2,
         numerical_feat_dim=0,
         cat_feat_dim=0,
+        class_weights=None,
         **kwargs
     ):
         self.mlp_division = mlp_division
@@ -45,3 +46,4 @@ class TabularConfig:
         self.numerical_feat_dim = numerical_feat_dim
         self.cat_feat_dim = cat_feat_dim
         self.num_labels = num_labels
+        self.class_weights=  class_weights

--- a/multimodal_transformers/model/tabular_config.py
+++ b/multimodal_transformers/model/tabular_config.py
@@ -1,8 +1,6 @@
 class TabularConfig:
     r"""Config used for tabular combiner
 
-
-
     Args:
         mlp_division (int): how much to decrease each MLP dim for each additional layer
         combine_feat_method (str): The method to combine categorical and numerical features.
@@ -46,4 +44,4 @@ class TabularConfig:
         self.numerical_feat_dim = numerical_feat_dim
         self.cat_feat_dim = cat_feat_dim
         self.num_labels = num_labels
-        self.class_weights=  class_weights
+        self.class_weights = class_weights

--- a/multimodal_transformers/model/tabular_modeling_auto.py
+++ b/multimodal_transformers/model/tabular_modeling_auto.py
@@ -10,7 +10,7 @@ from transformers import (
     RobertaConfig,
     XLNetConfig,
     XLMConfig,
-    XLMRobertaConfig
+    XLMRobertaConfig,
 )
 
 from .tabular_transformers import (
@@ -21,7 +21,7 @@ from .tabular_transformers import (
     AlbertWithTabular,
     XLNetWithTabular,
     XLMWithTabular,
-    XLMRobertaWithTabular
+    XLMRobertaWithTabular,
 )
 
 
@@ -34,7 +34,7 @@ MODEL_FOR_SEQUENCE_W_TABULAR_CLASSIFICATION_MAPPING = OrderedDict(
         (AlbertConfig, AlbertWithTabular),
         (XLNetConfig, XLNetWithTabular),
         (XLMConfig, XLMWithTabular),
-        (XLMRobertaConfig, XLMRobertaWithTabular)
+        (XLMRobertaConfig, XLMRobertaWithTabular),
     ]
 )
 

--- a/multimodal_transformers/model/tabular_transformers.py
+++ b/multimodal_transformers/model/tabular_transformers.py
@@ -47,6 +47,7 @@ class BertWithTabular(BertForSequenceClassification):
         else:
             self.config.tabular_config = tabular_config.__dict__
 
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.hidden_dropout_prob
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -83,15 +84,12 @@ class BertWithTabular(BertForSequenceClassification):
         head_mask=None,
         inputs_embeds=None,
         labels=None,
-        class_weights=None,
         output_attentions=None,
         output_hidden_states=None,
         cat_feats=None,
         numerical_feats=None,
     ):
         r"""
-            class_weights (:obj:`torch.FloatTensor` of shape :obj:`(tabular_config.num_labels,)`, `optional`, defaults to :obj:`None`):
-                Class weights to be used for cross entropy loss function for classification task
             labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`, defaults to :obj:`None`):
                 Labels for computing the sequence classification/regression loss.
                 Indices should be in :obj:`[0, ..., config.num_labels - 1]`.
@@ -131,7 +129,7 @@ class BertWithTabular(BertForSequenceClassification):
             self.tabular_classifier,
             labels,
             self.num_labels,
-            class_weights,
+            self.class_weights,
         )
         return loss, logits, classifier_layer_outputs
 
@@ -156,7 +154,8 @@ class RobertaWithTabular(RobertaForSequenceClassification):
             tabular_config = TabularConfig(**tabular_config)
         else:
             self.config.tabular_config = tabular_config.__dict__
-
+        
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.hidden_dropout_prob
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -196,13 +195,10 @@ class RobertaWithTabular(RobertaForSequenceClassification):
         labels=None,
         output_attentions=None,
         output_hidden_states=None,
-        class_weights=None,
         cat_feats=None,
         numerical_feats=None,
     ):
         r"""
-            class_weights (:obj:`torch.FloatTensor` of shape :obj:`(tabular_config.num_labels,)`, `optional`, defaults to :obj:`None`):
-                Class weights to be used for cross entropy loss function for classification task
             labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`, defaults to :obj:`None`):
                 Labels for computing the sequence classification/regression loss.
                 Indices should be in :obj:`[0, ..., config.num_labels - 1]`.
@@ -244,7 +240,7 @@ class RobertaWithTabular(RobertaForSequenceClassification):
             self.tabular_classifier,
             labels,
             self.num_labels,
-            class_weights,
+            self.class_weights,
         )
         return loss, logits, classifier_layer_outputs
 
@@ -279,6 +275,7 @@ class DistilBertWithTabular(DistilBertForSequenceClassification):
         else:
             self.config.tabular_config = tabular_config.__dict__
 
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.seq_classif_dropout
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -315,13 +312,10 @@ class DistilBertWithTabular(DistilBertForSequenceClassification):
         labels=None,
         output_attentions=None,
         output_hidden_states=None,
-        class_weights=None,
         cat_feats=None,
         numerical_feats=None,
     ):
         r"""
-            class_weights (:obj:`torch.FloatTensor` of shape :obj:`(tabular_config.num_labels,)`,`optional`, defaults to :obj:`None`):
-                Class weights to be used for cross entropy loss function for classification task
             labels (:obj:`torch.LongTensor` of shape :obj:`(batch_size,)`, `optional`, defaults to :obj:`None`):
                 Labels for computing the sequence classification/regression loss.
                 Indices should be in :obj:`[0, ..., config.num_labels - 1]`.
@@ -361,7 +355,7 @@ class DistilBertWithTabular(DistilBertForSequenceClassification):
             self.tabular_classifier,
             labels,
             self.num_labels,
-            class_weights,
+            self.class_weights,
         )
         return loss, logits, classifier_layer_outputs
 
@@ -387,6 +381,7 @@ class AlbertWithTabular(AlbertForSequenceClassification):
         else:
             self.config.tabular_config = tabular_config.__dict__
 
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.hidden_dropout_prob
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -424,7 +419,6 @@ class AlbertWithTabular(AlbertForSequenceClassification):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
-        class_weights=None,
         cat_feats=None,
         numerical_feats=None,
     ):
@@ -462,7 +456,7 @@ class AlbertWithTabular(AlbertForSequenceClassification):
             self.tabular_classifier,
             labels,
             self.num_labels,
-            class_weights,
+            self.class_weights,
         )
         return loss, logits, classifier_layer_outputs
 
@@ -491,6 +485,7 @@ class XLNetWithTabular(XLNetForSequenceClassification):
         else:
             self.config.tabular_config = tabular_config.__dict__
 
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.dropout
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -534,7 +529,6 @@ class XLNetWithTabular(XLNetForSequenceClassification):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
-        class_weights=None,
         cat_feats=None,
         numerical_feats=None,
     ):
@@ -574,7 +568,7 @@ class XLNetWithTabular(XLNetForSequenceClassification):
             self.tabular_classifier,
             labels,
             self.num_labels,
-            class_weights,
+            self.class_weights,
         )
         return loss, logits, classifier_layer_outputs
 
@@ -603,6 +597,7 @@ class XLMWithTabular(XLMForSequenceClassification):
         else:
             self.config.tabular_config = tabular_config.__dict__
 
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.dropout = hf_model_config.dropout
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -643,7 +638,6 @@ class XLMWithTabular(XLMForSequenceClassification):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
-        class_weights=None,
         cat_feats=None,
         numerical_feats=None,
     ):
@@ -681,7 +675,7 @@ class XLMWithTabular(XLMForSequenceClassification):
             self.tabular_classifier,
             labels,
             self.num_labels,
-            class_weights,
+            self.class_weights,
         )
         return loss, logits, classifier_layer_outputs
 
@@ -698,6 +692,7 @@ class LongformerWithTabular(LongformerForSequenceClassification):
         else:
             self.config.tabular_config = tabular_config.__dict__
 
+        self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.hidden_dropout_prob
         self.tabular_combiner = TabularFeatCombiner(tabular_config)
@@ -737,7 +732,6 @@ class LongformerWithTabular(LongformerForSequenceClassification):
         output_attentions=None,
         output_hidden_states=None,
         #return_dict=None,
-        class_weights=None,
         cat_feats=None,
         numerical_feats=None
     ):
@@ -769,5 +763,5 @@ class LongformerWithTabular(LongformerForSequenceClassification):
                                                               self.tabular_classifier,
                                                               labels,
                                                               self.num_labels,
-                                                              class_weights)
+                                                              self.class_weights)
         return loss, logits, classifier_layer_outputs

--- a/multimodal_transformers/model/tabular_transformers.py
+++ b/multimodal_transformers/model/tabular_transformers.py
@@ -7,7 +7,7 @@ from transformers import (
     AlbertForSequenceClassification,
     XLNetForSequenceClassification,
     XLMForSequenceClassification,
-    LongformerForSequenceClassification
+    LongformerForSequenceClassification,
 )
 from transformers.models.bert.modeling_bert import BERT_INPUTS_DOCSTRING
 from transformers.models.roberta.modeling_roberta import ROBERTA_INPUTS_DOCSTRING
@@ -17,7 +17,9 @@ from transformers.models.distilbert.modeling_distilbert import (
 from transformers.models.albert.modeling_albert import ALBERT_INPUTS_DOCSTRING
 from transformers.models.xlnet.modeling_xlnet import XLNET_INPUTS_DOCSTRING
 from transformers.models.xlm.modeling_xlm import XLM_INPUTS_DOCSTRING
-from transformers.models.longformer.modeling_longformer import LONGFORMER_INPUTS_DOCSTRING
+from transformers.models.longformer.modeling_longformer import (
+    LONGFORMER_INPUTS_DOCSTRING,
+)
 from transformers.models.xlm_roberta.configuration_xlm_roberta import XLMRobertaConfig
 from transformers.file_utils import add_start_docstrings_to_model_forward
 
@@ -154,7 +156,7 @@ class RobertaWithTabular(RobertaForSequenceClassification):
             tabular_config = TabularConfig(**tabular_config)
         else:
             self.config.tabular_config = tabular_config.__dict__
-        
+
         self.class_weights = tabular_config.class_weights
         tabular_config.text_feat_dim = hf_model_config.hidden_size
         tabular_config.hidden_dropout_prob = hf_model_config.hidden_dropout_prob
@@ -679,12 +681,13 @@ class XLMWithTabular(XLMForSequenceClassification):
         )
         return loss, logits, classifier_layer_outputs
 
+
 class LongformerWithTabular(LongformerForSequenceClassification):
     """
     Longformer Model With Sequence Classification Head
     """
-    def __init__(self, hf_model_config): #, embedding_weights=None):
-        #hf_model_config.summary_proj_to_labels=False #Added from XLM example
+
+    def __init__(self, hf_model_config):
         super().__init__(hf_model_config)
         tabular_config = hf_model_config.tabular_config
         if type(tabular_config) is dict:  # when loading from saved model
@@ -700,68 +703,60 @@ class LongformerWithTabular(LongformerForSequenceClassification):
         combined_feat_dim = self.tabular_combiner.final_out_dim
         self.dropout = nn.Dropout(hf_model_config.hidden_dropout_prob)
         if tabular_config.use_simple_classifier:
-            self.tabular_classifier = nn.Linear(combined_feat_dim,
-                                                tabular_config.num_labels)
+            self.tabular_classifier = nn.Linear(
+                combined_feat_dim, tabular_config.num_labels
+            )
         else:
-            dims = calc_mlp_dims(combined_feat_dim,
-                                 division=tabular_config.mlp_division,
-                                 output_dim=tabular_config.num_labels)
-            self.tabular_classifier = MLP(combined_feat_dim,
-                                          tabular_config.num_labels,
-                                          num_hidden_lyr=len(dims),
-                                          dropout_prob=tabular_config.mlp_dropout,
-                                          hidden_channels=dims,
-                                          bn=True)
+            dims = calc_mlp_dims(
+                combined_feat_dim,
+                division=tabular_config.mlp_division,
+                output_dim=tabular_config.num_labels,
+            )
+            self.tabular_classifier = MLP(
+                combined_feat_dim,
+                tabular_config.num_labels,
+                num_hidden_lyr=len(dims),
+                dropout_prob=tabular_config.mlp_dropout,
+                hidden_channels=dims,
+                bn=True,
+            )
 
-        # load embeddings
-        #self.embedding_layer = nn.Embedding.from_pretrained(torch.from_numpy(embedding_weights).float(), freeze=True)
-        #self.embedding_layer = nn.Embedding()
-          
-    @add_start_docstrings_to_model_forward(LONGFORMER_INPUTS_DOCSTRING.format("(batch_size, sequence_length)"))
+    @add_start_docstrings_to_model_forward(
+        LONGFORMER_INPUTS_DOCSTRING.format("(batch_size, sequence_length)")
+    )
     def forward(
         self,
-        #input_ids(torch.LongTensor(batch_size, sequence_length)),
         input_ids=None,
         attention_mask=None,
         token_type_ids=None,
         position_ids=None,
-        #global_attention_mask=None,
         head_mask=None,
         inputs_embeds=None,
         labels=None,
         output_attentions=None,
         output_hidden_states=None,
-        #return_dict=None,
         cat_feats=None,
-        numerical_feats=None
+        numerical_feats=None,
     ):
-#         if global_attention_mask is None:
-#             print("Initializing global attention on CLS token...")
-#             global_attention_mask = torch.zeros_like(input_ids)
-#             # global attention on cls token
-#             global_attention_mask[:, 0] = 1
-
         outputs = self.longformer(
             input_ids,
             attention_mask=attention_mask,
-            #global_attention_mask=global_attention_mask,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             head_mask=head_mask,
             inputs_embeds=inputs_embeds,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
-            #return_dict=return_dict,
         )
-        sequence_output = outputs[0] #added from Roberta
-        text_feats = sequence_output[:,0,:] #added from Roberta
-        text_feats = self.dropout(text_feats) #added from Roberta
-        combined_feats = self.tabular_combiner(text_feats,
-                                               cat_feats,
-                                               numerical_feats)
-        loss, logits, classifier_layer_outputs = hf_loss_func(combined_feats,
-                                                              self.tabular_classifier,
-                                                              labels,
-                                                              self.num_labels,
-                                                              self.class_weights)
+        sequence_output = outputs[0]  # added from Roberta
+        text_feats = sequence_output[:, 0, :]  # added from Roberta
+        text_feats = self.dropout(text_feats)  # added from Roberta
+        combined_feats = self.tabular_combiner(text_feats, cat_feats, numerical_feats)
+        loss, logits, classifier_layer_outputs = hf_loss_func(
+            combined_feats,
+            self.tabular_classifier,
+            labels,
+            self.num_labels,
+            self.class_weights,
+        )
         return loss, logits, classifier_layer_outputs


### PR DESCRIPTION
* Reset index before preprocessing as categorical preprocessing resets the index which in turn causes issues when merging it with the numerical & text features.
* Class weights have been removed from the dataset and preprocessing sections. This was not usable and even when set resulted in errors. Instead it is now a parameter in TabularConfig and is used by the model in the forward() call.
* Minor cleanup of comments and formatting with black.